### PR TITLE
fix tabel associations

### DIFF
--- a/db.js
+++ b/db.js
@@ -12,8 +12,8 @@ const sequelize = new Sequelize({
 const User = UserModel(sequelize);
 const Event = EventModel(sequelize);
 
-User.hasMany(Event);
-Event.belongsTo(User);
+User.hasMany(Event, { foreignKey: "organizerId" });
+Event.belongsTo(User, { foreignKey: "organizerId" });
 
 try {
   await sequelize.sync({ force: false });


### PR DESCRIPTION
Was missing to explicitly name the foreign key when making the association between table, Which resulted in having an extra key with a null value when retrieving the events. 