### PR TITLE
run hooks on bulk creation

### DIFF
--- a/seed.js
+++ b/seed.js
@@ -72,8 +72,8 @@ const seedDB = async () => {
     },
   ];
 
-  await User.bulkCreate(users);
-  await Event.bulkCreate(events);
+  await User.bulkCreate(users, { individualHooks: true });
+  await Event.bulkCreate(events, { individualHooks: true });
 };
 
 try {


### PR DESCRIPTION
The model hooks were not running on bulk creation so the hashed password and lowercased email were not present in the users that were created using the seed file